### PR TITLE
Do not call any command unless all arguments are valid

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -503,3 +503,20 @@ def test_can_chain_command_calls(capsys):
     assert "Other command param is myparam" in out
     assert out.count('before') == 1
     assert out.count('after') == 1
+
+
+def test_do_not_call_any_command_with_unkown_extra(capsys):
+
+    @cli
+    def mycommand(param):
+        print(param)
+
+    run('mycommand', 'success')
+    out, err = capsys.readouterr()
+    assert "success" in out
+
+    with pytest.raises(SystemExit):
+        run('mycommand', 'success', 'failed')
+    out, err = capsys.readouterr()
+    assert "success" not in out
+    assert "failed" not in out


### PR DESCRIPTION
Since chained commands are allowed, this call would still execute
"mycommand" (and then complain about the unknown "unknownarg" command):

    myscript mycommand arg1 arg2 unknownarg

This commit prevents that.