### PR TITLE
Run a single command without subcommands.

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 0.5.2
+
+ - allow run to optionally accept a callable to use as the only command
+
 ## 0.5.1
 
 - fix use of append action (`my_kwarg=[]`, then `--my-kwarg=foo --my-kwarg=bar`)

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -90,7 +90,7 @@ For instance:
 allows you to call the script without specifying a command:
 
     $ python script.py a_param
-    ->  a param
+    ->  a_param
 
 
 ### Global parameters

--- a/docs/reference.md
+++ b/docs/reference.md
@@ -76,6 +76,23 @@ See [how-to guides](how-to.md) for concrete usage examples.
     if __name__ == '__main__':
         run()
 
+If run is called with a callable as first argument, it will treat that callable as the only command.
+No additional command argument will be required to run it.
+
+For instance:
+
+    def my_callable(param):
+        print(param)
+    
+    if __name__ == '__main__':
+        run(my_callable)
+    
+allows you to call the script without specifying a command:
+
+    $ python script.py a_param
+    ->  a param
+
+
 ### Global parameters
 
 Any kwarg passed to `run` will be turned to a global parameter.

--- a/minicli/__init__.py
+++ b/minicli/__init__.py
@@ -1,5 +1,6 @@
 import argparse
 import asyncio
+import sys
 import inspect
 
 NO_DEFAULT = inspect._empty
@@ -62,16 +63,19 @@ class Cli:
         except IndexError:
             return ''
 
-    def init_parser(self, subparsers):
-        kwargs = {
-            'help': self.short_help,
-            'conflict_handler': 'resolve'
-        }
+    def create_name(self, kwargs):
         name = self.command.__name__
         if '_' in name:
             kwargs['aliases'] = [name]
             name = name.replace('_', '-')
         kwargs['name'] = name
+
+    def init_parser(self, subparsers):
+        kwargs = {
+            'help': self.short_help,
+            'conflict_handler': 'resolve'
+        }
+        self.create_name(kwargs)
         kwargs.update(self.extra.get('__self__', {}))
         self.parser = subparsers.add_parser(**kwargs)
         self.set_defaults(func=self.invoke)
@@ -118,7 +122,16 @@ def cli(*args, **kwargs):
     return func
 
 
+def _run_single(method, *input, **shared):
+    cli(method)
+    name = method.__name__
+    run(name, *input or sys.argv[1:], **shared)
+    
+
 def run(*input, **shared):
+    if len(input)  and callable(input[0]):
+        _run_single(*input, **shared)
+        return
     parser = argparse.ArgumentParser(add_help=False)
     for arg_name, kwargs in shared.items():
         if not isinstance(kwargs, dict):

--- a/minicli/__init__.py
+++ b/minicli/__init__.py
@@ -1,6 +1,7 @@
 import argparse
 import asyncio
 import sys
+import warnings
 import inspect
 
 NO_DEFAULT = inspect._empty
@@ -120,12 +121,6 @@ def cli(*args, **kwargs):
         extra[args[1]] = kwargs
     Cli(func, **extra)
     return func
-
-
-def _run_single(method, *input, **shared):
-    cli(method)
-    name = method.__name__
-    run(name, *input or sys.argv[1:], **shared)
     
 
 def run(*input, **shared):
@@ -170,6 +165,20 @@ def run(*input, **shared):
             command.func(command, **shared)
     finally:
         call_wrappers()
+
+
+def _run_single(method, *input, **shared):
+    cli(method)
+    name = method.__name__
+    run(name, *input or sys.argv[1:], **shared)
+
+
+def command(*args, **kwargs):
+    """For pyminiCLI retrocomaptibility."""
+    warnings.warn("This function is only to ease migration"
+                  " from pyminiCLI. Use run() instead.",
+                  DeprecationWarning)
+    return run(*args, **kwargs)
 
 
 def wrap(func):

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -553,3 +553,19 @@ def test_run_without_declaring_command(capsys):
     run(mycommand, 'a param')
     out, err = capsys.readouterr()
     assert "a param" in out
+    
+
+def test_single_command_cli(capsys):
+
+    @cli('param', nargs=4)
+    def mycommand(param=[1, 2, 3, 4]):
+        print(param)
+
+    run(mycommand, '--param', '1', '2', '3', '4')
+    out, err = capsys.readouterr()
+    assert "['1', '2', '3', '4']" in out
+
+    with pytest.raises(SystemExit):
+        run(mycommand, '--param', '1', '2', '3')
+    out, err = capsys.readouterr()
+    assert "argument --param/-p: expected 4 arguments" in err

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -542,3 +542,14 @@ def test_do_not_call_any_command_with_unkown_extra(capsys):
     out, err = capsys.readouterr()
     assert "success" not in out
     assert "failed" not in out
+
+
+def test_run_without_declaring_command(capsys):
+
+    def mycommand(param):
+        print(param)
+        return
+
+    run(mycommand, 'a param')
+    out, err = capsys.readouterr()
+    assert "a param" in out


### PR DESCRIPTION
Some time ago I started https://github.com/HDictus/pyminiCLI. It is very similar to minicli and with this PR it will be entirely obsolete.

Minicli already supports a lot of the functionality I was planning to implement.
The only difference is that while pyminiCLI assumes a CLI tool does a single thing, minicli assumes a CLI tool has sub-commands. 
Implementing the ability to do the former in minicli turned out to be fairly trivial.

So now, if you do:

```
# script.py
from minicli import run
def my_callable(param):
     print(param)
    
if __name__ == '__main__':
    run(my_callable)
```
You can do 

```
    $ python script.py a_param
    ->  a_param
```
without the need for a sub-command.

I hope you also consider this functionality useful.
I have a bunch of other code that uses pyminicli, which I can easily migrate to minicli if this is merged.
